### PR TITLE
Fix bug in '.getMSigDB' function

### DIFF
--- a/R/getGenesets.R
+++ b/R/getGenesets.R
@@ -355,6 +355,7 @@ writeGMT <- function(gs, gmt.file)
                         cat = c("H", paste0("C", 1:8)), 
                         subcat = NA)
 {
+    cat <- match.arg(cat)
     isAvailable("msigdbr", type = "software")
     supp.cats <- unique(msigdbr::msigdbr_collections()$gs_cat)
     if(!(cat %in% supp.cats))


### PR DESCRIPTION
Hello!
Thank you for this R package. After some update I've noticed that the `getGenesets` function  stopped working with "misgdb" database. Here is an example of the error:
```R
> geneSets <- EnrichmentBrowser::getGenesets("hsa", "msigdb")
Error in msigdbr::msigdbr(morg, cat, subcat) : 
  please specify only one category at a time
In addition: Warning message:
In if (!(cat %in% supp.cats)) stop(gettextf("'cat' should be one of %s",  :
  the condition has length > 1 and only the first element will be used
```
And this is my `sessionInfo()` output: 
```R
R version 4.1.0 (2021-05-18)
Platform: x86_64-pc-linux-gnu (64-bit)
Running under: Ubuntu 20.04.2 LTS

Matrix products: default
BLAS:   /usr/lib/x86_64-linux-gnu/blas/libblas.so.3.9.0
LAPACK: /usr/lib/x86_64-linux-gnu/lapack/liblapack.so.3.9.0

locale:
 [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C               LC_TIME=ru_RU.UTF-8       
 [4] LC_COLLATE=en_US.UTF-8     LC_MONETARY=ru_RU.UTF-8    LC_MESSAGES=en_US.UTF-8   
 [7] LC_PAPER=ru_RU.UTF-8       LC_NAME=C                  LC_ADDRESS=C              
[10] LC_TELEPHONE=C             LC_MEASUREMENT=ru_RU.UTF-8 LC_IDENTIFICATION=C       

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] msigdbr_7.4.1

loaded via a namespace (and not attached):
 [1] KEGGgraph_1.52.0            Rcpp_1.0.7                  lattice_0.20-44            
 [4] png_0.1-7                   Biostrings_2.60.1           assertthat_0.2.1           
 [7] utf8_1.2.1                  BiocFileCache_2.0.0         R6_2.5.0                   
[10] GenomeInfoDb_1.28.1         stats4_4.1.0                RSQLite_2.2.7              
[13] httr_1.4.2                  pillar_1.6.1                zlibbioc_1.38.0            
[16] rlang_0.4.11                curl_4.3.2                  rstudioapi_0.13            
[19] annotate_1.70.0             Rgraphviz_2.36.0            blob_1.2.1                 
[22] S4Vectors_0.30.0            Matrix_1.3-4                RCurl_1.98-1.3             
[25] bit_4.0.4                   DelayedArray_0.18.0         compiler_4.1.0             
[28] pkgconfig_2.0.3             BiocGenerics_0.38.0         tidyselect_1.1.1           
[31] SummarizedExperiment_1.22.0 KEGGREST_1.32.0             tibble_3.1.2               
[34] GenomeInfoDbData_1.2.6      IRanges_2.26.0              matrixStats_0.59.0         
[37] XML_3.99-0.6                fansi_0.5.0                 withr_2.4.2                
[40] dbplyr_2.1.1                crayon_1.4.1                dplyr_1.0.7                
[43] rappdirs_0.3.3              bitops_1.0-7                grid_4.1.0                 
[46] xtable_1.8-4                GSEABase_1.54.0             lifecycle_1.0.0            
[49] DBI_1.1.1                   magrittr_2.0.1              graph_1.70.0               
[52] cachem_1.0.5                XVector_0.32.0              EnrichmentBrowser_2.22.1   
[55] filelock_1.0.2              ellipsis_0.3.2              vctrs_0.3.8                
[58] generics_0.1.0              tools_4.1.0                 bit64_4.0.5                
[61] Biobase_2.52.0              glue_1.4.2                  purrr_0.3.4                
[64] MatrixGenerics_1.4.0        parallel_4.1.0              fastmap_1.1.0              
[67] babelgene_21.4              AnnotationDbi_1.54.1        GenomicRanges_1.44.0       
[70] memoise_2.0.0
```
In fact, the line that I restored was in the previous version of your package.