### PR TITLE
Fix .getMsigDb for updated msigdbr argument order

### DIFF
--- a/R/getGenesets.R
+++ b/R/getGenesets.R
@@ -386,7 +386,7 @@ writeGMT <- function(gs, gmt.file)
         stop("Organism not supported")
     
     scat <- if(is.na(subcat)) NULL else subcat
-    df <- msigdbr::msigdbr(dorg, morg, cat, scat)
+    df <- msigdbr::msigdbr(species = morg, db_species = dorg, collection = cat, subcollection = scat)
     gs <- split(as.character(df$ncbi_gene), df$gs_id)
     gs.names <- unique(df$gs_name)
     gs.ids <- unique(df$gs_id)


### PR DESCRIPTION
This fix addresses issue **#55**.

The problem was caused by a change in the argument order of the `msigdbr::msigdbr` function. The signature was updated [from](https://github.com/igordot/msigdbr/blob/1cc6423941e3bd3f05cff9b55b02a3815ecc8695/R/msigdbr.R#L41):

```r
msigdbr <- function(species = "Homo sapiens", db_species = "HS", collection = NULL, subcollection = NULL, category = deprecated(), subcategory = deprecated())
```

[to](https://github.com/igordot/msigdbr/blob/326de319db336929145a543d3b7191297ff606db/R/msigdbr.R#L41):

```r
msigdbr <- function(db_species = "HS", species = "human", collection = NULL, subcollection = NULL, category = deprecated(), subcategory = deprecated())
```

This pull request switches from positional to named arguments, ensuring compatibility with the new function signature and resolving the error I encountered.